### PR TITLE
Fix regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -13,9 +13,6 @@
 from SublimeLinter.lint import RubyLinter, util
 import re
 
-
-# SublimeLinter: WARNING: reek: Implicit appending a filename to `cmd` has been deprecated, add '${temp_file}' explicitly.
-
 class Reek(RubyLinter):
     """Provides an interface to reek."""
 

--- a/linter.py
+++ b/linter.py
@@ -22,9 +22,12 @@ class Reek(RubyLinter):
     defaults = {
         'selector': 'source.ruby - text.html - text.haml'
     }
-    cmd = ('ruby', '-S', 'reek')
-    regex = r'^.+?\[(?P<line>\d+).*\]:(?P<message>.+) \[.*\]'
+
+    cmd = ('ruby', '-S', 'reek', '-s', '--no-color',
+           '--no-progress', '--no-documentation', '${temp_file}')
+    regex = r'^.+?:(?P<line>\d+): (?P<error>\w+): (?P<message>.+)$'
     tempfile_suffix = 'rb'
+    config_file = ('-c', '.reek.yml')
 
 
     def split_match(self, match):

--- a/linter.py
+++ b/linter.py
@@ -10,8 +10,9 @@
 
 """This module exports the Reek plugin class."""
 
-from SublimeLinter.lint import RubyLinter, util
+from SublimeLinter.lint import RubyLinter
 import re
+
 
 class Reek(RubyLinter):
     """Provides an interface to reek."""
@@ -21,19 +22,18 @@ class Reek(RubyLinter):
     }
 
     cmd = ('ruby', '-S', 'reek', '-s', '--no-color',
-           '--no-progress', '--no-documentation', '${temp_file}')
+           '--no-progress', '--no-documentation', '${file}')
     regex = r'^.+?:(?P<line>\d+): (?P<error>\w+): (?P<message>.+)$'
     tempfile_suffix = 'rb'
-    config_file = ('-c', '.reek.yml')
 
 
     def split_match(self, match):
         """Extract named capture groups from the regex and return them as a tuple."""
 
-        match, line, col, error, warning, message, _ = super().split_match(match)
-        near = self.search_token(message)
+        error = super().split_match(match)
+        error['near'] = self.search_token(error['message'])
 
-        return match, line, col, error, warning, message, near
+        return error
 
     def search_token(self, message):
         """Search text token to be highlighted."""


### PR DESCRIPTION
Used [this Pythex](https://pythex.org/?regex=%5E.%2B%3F%3A(%3FP%3Cline%3E%5Cd%2B)%3A%20(%3FP%3Ccode%3E%5Cw%2B)%3A%20(%3FP%3Cmessage%3E.%2B)%24&test_string=%2FT%2Ftmpbboz72.rb%20--%202%20warnings%3A%0A%20%20%20%20%2FT%2Ftmpbboz72.rb%3A21%3A%20FeatureEnvy%3A%20Integrations%3A%3AWriters%3A%3AWriteLocation%23find_or_create_location%20refers%20to%20%27normalized_location_data%27%20more%20than%20self%20(maybe%20move%20it%20to%20another%20class%3F)%0A%20%20%20%20%2FT%2Ftmpbboz72.rb%3A36%3A%20UtilityFunction%3A%20Integrations%3A%3AWriters%3A%3AWriteLocation%23location_valid%3F%20doesn%27t%20depend%20on%20instance%20state%20(maybe%20move%20it%20to%20another%20class%3F)&ignorecase=0&multiline=1&dotall=0&verbose=0)

Also fixed default config file and the warning. 